### PR TITLE
fix: change dependabot commit prefix

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
       interval: "daily"
     commit-message:
       # Prefix all commit messages with "chore(dependabot): "
-      prefix: "chore(dependabot): "
+      prefix: "fix(dependabot): "
     groups:
       all:
         patterns:


### PR DESCRIPTION
# Description

Change the dependabot commit prefix from chore to fix to integrate these PRs to the release.